### PR TITLE
Use non-interactive apt operations in setup script

### DIFF
--- a/Alis_Script.sh
+++ b/Alis_Script.sh
@@ -42,8 +42,8 @@ TARGET_USER="${SUDO_USER:-$USER}"
 
 # 1) System packages (use distro packages for stability)
 step "Installing system Python packages…"
-apt update
-apt install -y \
+DEBIAN_FRONTEND=noninteractive apt-get -y -q update
+DEBIAN_FRONTEND=noninteractive apt-get -y -q install \
   python3 python3-pip \
   python3-pil python3-numpy python3-spidev python3-gpiozero python3-lgpio \
   raspi-config


### PR DESCRIPTION
## Summary
- ensure apt-get update/install run non-interactively and quietly

## Testing
- `bash -n Alis_Script.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aea6bde510833093edd06f51c4272e