### PR TITLE
docs: expand project README with setup and usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
 # Alis_2
+
+## Project Description
+Alis 2 is a Python-driven menu interface for Raspberry Pi devices equipped with a small Waveshare LCD.  The application renders a themed UI and listens for button input through dedicated threads, persisting configuration to disk so that settings survive reboots.
+
+## Hardware Dependencies
+- Raspberry Pi with SPI enabled
+- Waveshare 2" SPI LCD (tested with the Waveshare 2 inch module)
+- Momentary buttons wired to GPIO pins
+- Python library [`gpiozero`](https://gpiozero.readthedocs.io/) for handling button input
+
+## Setup
+1. Enable SPI on the Raspberry Pi (`sudo raspi-config`).
+2. Clone this repository and move into the project directory.
+3. Install Python requirements and the gpiozero library:
+
+   ```bash
+   sudo apt-get update && sudo apt-get install python3-pip python3-gpiozero
+   pip3 install pillow
+   ```
+
+## Usage
+Run the main application to launch the menu system on the LCD:
+
+```bash
+python3 app/main.py
+```
+
+Use the connected buttons to navigate the on‑screen menu.  Settings are stored in `settings.json` and persist across restarts.
+
+## Quick Start Example
+
+```bash
+git clone <repository-url>
+cd Alis_2
+python3 app/main.py
+```
+
+This boots the UI with the default menu defined in `menu.json`.
+
+## Contribution Guidelines
+Contributions are welcome!  Please open an issue or pull request with proposed changes.  Keep commits focused, follow Python best practices, and run the available tests before submitting.


### PR DESCRIPTION
## Summary
- document project description and hardware requirements
- add setup, usage, quick start, and contribution sections

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeaa3d81c483309e047c393ff87b03