### PR TITLE
Handle invalid brightness values

### DIFF
--- a/app/interface.py
+++ b/app/interface.py
@@ -21,6 +21,7 @@
 
 import time
 import threading
+import logging
 from typing import Dict, Any, Callable
 from PIL import Image, Image as PILImage
 from driver import LCD_2inch
@@ -91,7 +92,12 @@ class DisplayThread(threading.Thread):
     # -------- helpers --------
     def _apply_brightness(self, val: int):
         """Map 0..100 to driver backlight if available; fallback on/off."""
-        val = max(0, min(100, int(val)))
+        try:
+            val = int(val)
+        except (ValueError, TypeError):
+            logging.warning("Invalid brightness value %r; defaulting to 100", val)
+            val = 100
+        val = max(0, min(100, val))
         try:
             # Many Waveshare drivers accept 0..100 for duty
             self.disp.bl_DutyCycle(val)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Stub out hardware-dependent modules before importing DisplayThread
+
+driver_pkg = types.ModuleType("driver")
+lcd_module = types.ModuleType("LCD_2inch")
+
+class DummyLCD:
+    def __init__(self):
+        self.last = None
+    def Init(self):
+        pass
+    def bl_DutyCycle(self, val):
+        self.last = val
+    width = 0
+    height = 0
+
+lcd_module.LCD_2inch = DummyLCD
+driver_pkg.LCD_2inch = lcd_module
+sys.modules['driver'] = driver_pkg
+sys.modules['driver.LCD_2inch'] = lcd_module
+
+gpiozero_module = types.ModuleType("gpiozero")
+class Button:
+    pass
+gpiozero_module.Button = Button
+sys.modules['gpiozero'] = gpiozero_module
+
+# Minimal PIL stub
+pil_module = types.ModuleType("PIL")
+pil_image_module = types.ModuleType("PIL.Image")
+class Image:
+    class Transpose:
+        ROTATE_270 = ROTATE_180 = ROTATE_90 = 0
+    @staticmethod
+    def new(mode, size, color):
+        return None
+pil_image_module.Image = Image
+pil_module.Image = pil_image_module
+pil_module.ImageDraw = types.SimpleNamespace()
+pil_module.ImageFont = types.SimpleNamespace()
+sys.modules['PIL'] = pil_module
+sys.modules['PIL.Image'] = pil_image_module
+
+from app.interface import DisplayThread
+
+
+class ApplyBrightnessTest(unittest.TestCase):
+    def test_invalid_input_defaults_and_warns(self):
+        dt = DisplayThread.__new__(DisplayThread)
+        dt.disp = DummyLCD()
+        with self.assertLogs(level='WARNING') as log:
+            dt._apply_brightness('oops')
+        self.assertEqual(dt.disp.last, 100)
+        self.assertTrue(any('Invalid brightness value' in m for m in log.output))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- guard brightness conversion against invalid values and warn before defaulting
- add regression test covering brightness fallback on bad input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeaa451c1c8330aaa0ca01781d06db