### PR TITLE
Avoid brightness flash during sleep

### DIFF
--- a/app/interface.py
+++ b/app/interface.py
@@ -154,9 +154,6 @@ class DisplayThread(threading.Thread):
                 settings = self.get_settings()
                 theme = self.get_theme()
 
-                # apply brightness if changed
-                self._apply_brightness(settings.get("display", {}).get("brightness", 100))
-
                 # idle time since last input
                 idle = time.time() - self.controller.last_input_ts
 
@@ -175,6 +172,9 @@ class DisplayThread(threading.Thread):
                     self._render_screensaver()
                     time.sleep(0.05)
                     continue
+
+                # apply brightness if changed (only when active)
+                self._apply_brightness(settings.get("display", {}).get("brightness", 100))
 
                 # normal render throttled
                 now = time.time()

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,7 +1,9 @@
 import os
 import sys
+import time
 import types
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -58,6 +60,40 @@ class ApplyBrightnessTest(unittest.TestCase):
             dt._apply_brightness('oops')
         self.assertEqual(dt.disp.last, 100)
         self.assertTrue(any('Invalid brightness value' in m for m in log.output))
+
+
+class RunLoopSleepTest(unittest.TestCase):
+    def test_brightness_not_restored_while_sleeping(self):
+        settings = {"display": {"brightness": 77, "sleep_seconds": 1}}
+
+        class DummyStop:
+            def __init__(self):
+                self.calls = 0
+
+            def is_set(self):
+                self.calls += 1
+                return self.calls > 1
+
+        dt = DisplayThread.__new__(DisplayThread)
+        dt.stop_evt = DummyStop()
+        dt.controller = types.SimpleNamespace(last_input_ts=0)
+        dt.status = types.SimpleNamespace(snapshot=lambda: {})
+        dt.get_theme = lambda: {}
+        dt.get_settings = lambda: settings
+        dt._screensaver = lambda idle, s: False
+
+        calls = []
+
+        def fake_apply(val):
+            calls.append(val)
+
+        dt._apply_brightness = fake_apply
+
+        with patch('time.sleep', lambda s: None):
+            dt.run()
+
+        self.assertTrue(calls)
+        self.assertEqual(set(calls), {0})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- prevent DisplayThread from reapplying user brightness before sleep check
- add regression test covering brightness during sleep

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeadaf9b248330adc315fe3cab7cd7