### PR TITLE
Add LED controller thread

### DIFF
--- a/app/led_controller.py
+++ b/app/led_controller.py
@@ -1,0 +1,72 @@
+"""app/led_controller.py
+
+Threaded controller for a 16x16 WS2812B LED matrix.
+Cycles through red, green, and blue test pattern.
+"""
+
+import logging
+import threading
+import time
+
+try:  # Try to import the real hardware library
+    from rpi_ws281x import PixelStrip, Color
+except Exception:  # pragma: no cover - hardware not present
+    PixelStrip = None  # type: ignore
+    def Color(r, g, b):  # type: ignore
+        return (r, g, b)
+    logging.warning("rpi_ws281x not available; LED controller will be a no-op")
+
+
+class LEDThread(threading.Thread):
+    """Simple LED controller thread.
+
+    Displays a solid color over the entire 16x16 matrix and rotates
+    through red, green and blue until the stop event is set.
+    Brightness is read from settings on each cycle if the hardware
+    library supports it.
+    """
+
+    def __init__(self, stop_evt: threading.Event, get_settings, count: int = 16 * 16, pin: int = 18):
+        super().__init__(daemon=True)
+        self.stop_evt = stop_evt
+        self.get_settings = get_settings
+        self.count = count
+        self.pin = pin
+        self.strip = None
+        if PixelStrip:
+            try:
+                brightness = int(get_settings().get("led", {}).get("brightness", 64))
+            except Exception:
+                brightness = 64
+            self.strip = PixelStrip(count, pin, brightness=brightness)
+            self.strip.begin()
+
+    def _set_all(self, color):
+        if not self.strip:
+            return
+        for i in range(self.count):
+            self.strip.setPixelColor(i, color)
+        self.strip.show()
+
+    def run(self):
+        if not self.strip:
+            # Hardware not available, just idle until stop
+            while not self.stop_evt.is_set():
+                time.sleep(0.5)
+            return
+
+        colors = [Color(255, 0, 0), Color(0, 255, 0), Color(0, 0, 255)]
+        idx = 0
+        while not self.stop_evt.is_set():
+            settings = self.get_settings()
+            try:
+                brightness = int(settings.get("led", {}).get("brightness", 64))
+                self.strip.setBrightness(brightness)
+            except Exception:
+                pass
+            self._set_all(colors[idx % 3])
+            idx += 1
+            time.sleep(0.5)
+
+        # Clear on exit
+        self._set_all(Color(0, 0, 0))

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from app.interface import DisplayThread, ButtonsThread
 from app.menu_engine import MenuController
 from app.status import StatusProvider
 from app.storage import load_json, save_json_atomic
+from app.led_controller import LEDThread
 
 # Paths are relative to the project root (where you run Alis_Script.sh)
 MENU_PATH     = "menu.json"
@@ -104,10 +105,12 @@ def main():
         rotation=rotation,              # <-- applied once at startup
     )
     btn_thread  = ButtonsThread(stop_evt=stop_evt, controller=controller)
+    led_thread  = LEDThread(stop_evt=stop_evt, get_settings=get_settings)
 
     try:
         disp_thread.start()
         btn_thread.start()
+        led_thread.start()
         # Main thread can host future supervisors/services
         while True:
             time.sleep(1.0)
@@ -118,6 +121,7 @@ def main():
         # Give threads a moment to exit cleanly
         btn_thread.join(timeout=2.0)
         disp_thread.join(timeout=3.0)
+        led_thread.join(timeout=2.0)
         # Ensure final settings are flushed
         save_json_atomic(SETTINGS_PATH, settings)
         print("[Alis] Stopped.")


### PR DESCRIPTION
## Summary
- add `LEDThread` to drive 16x16 WS2812B matrix with rotating RGB pattern
- start LED controller thread from `main.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeaf6056b48330836f680817a5fdb6