### PR TITLE
Use pip module for requirements installation

### DIFF
--- a/Alis_Script.sh
+++ b/Alis_Script.sh
@@ -56,7 +56,7 @@ DEBIAN_FRONTEND=noninteractive apt-get -y -q install \
   raspi-config
 
 step "Installing Python requirements…"
-pip3 install -r "$PROJECT_ROOT/requirements.txt"
+python3 -m pip --break-system-packages install -r "$PROJECT_ROOT/requirements.txt"
 
 # 2) Optionally enable SPI (Bookworm uses /boot/firmware/config.txt)
 if [[ $ENABLE_SPI -eq 1 ]]; then


### PR DESCRIPTION
## Summary
- Use `python3 -m pip --break-system-packages` to install requirements in Alis_Script.sh

## Testing
- `pytest -q`
- `USER=root ./Alis_Script.sh` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af4752a7a48330ab97e00d3861f7e1