### PR TITLE
Remove RPi.GPIO dependency and document lgpio usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Alis 2 is a Python-driven menu interface for Raspberry Pi devices equipped with 
 - Raspberry Pi with SPI enabled
 - Waveshare 2" SPI LCD (tested with the Waveshare 2 inch module)
 - Momentary buttons wired to GPIO pins
-- Python library [`gpiozero`](https://gpiozero.readthedocs.io/) for handling button input
+- Python library [`gpiozero`](https://gpiozero.readthedocs.io/) using the [`lgpio`](https://pypi.org/project/lgpio/) backend for handling button input (no `RPi.GPIO` required)
 
 ## Setup
 1. Enable SPI on the Raspberry Pi (`sudo raspi-config`).
@@ -18,6 +18,8 @@ Alis 2 is a Python-driven menu interface for Raspberry Pi devices equipped with 
    sudo apt-get update && sudo apt-get install python3-pip
    pip3 install -r requirements.txt
    ```
+
+These packages configure `gpiozero` to use the `lgpio` backend, so `RPi.GPIO` is not required.
 
 ## Usage
 Run the main application to launch the menu system on the LCD:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ numpy>=1.26
 
 # Raspberry Pi hardware access
 spidev>=3.6
-RPi.GPIO>=0.7.1
-gpiozero>=2.0
+gpiozero>=2.0  # uses lgpio backend; RPi.GPIO not required
 lgpio
 rpi-ws281x


### PR DESCRIPTION
## Summary
- Drop unused `RPi.GPIO` from requirements and note `gpiozero` relies on the `lgpio` backend.
- Update README to clarify that the project uses `lgpio` exclusively and `RPi.GPIO` isn't needed.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af475bb7b4833086407f5ec0b30fe5