### PR TITLE
Upgrade pip before installing requirements

### DIFF
--- a/Alis_Script.sh
+++ b/Alis_Script.sh
@@ -55,6 +55,9 @@ DEBIAN_FRONTEND=noninteractive apt-get -y -q install \
   python3 python3-pip \
   raspi-config
 
+step "Upgrading pip…"
+python3 -m pip install --upgrade pip
+
 step "Installing Python requirements…"
 python3 -m pip --break-system-packages install -r "$PROJECT_ROOT/requirements.txt"
 


### PR DESCRIPTION
## Summary
- Update setup script to upgrade pip before installing dependencies, preventing errors on older versions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af487a6d0c8330acc485cfe01ffc9f