### PR TITLE
Use pi5neo for LED control

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -110,8 +110,8 @@ def main():
     )
     btn_thread  = ButtonsThread(stop_evt=stop_evt, controller=controller)
 
-    # LED matrix data line is wired to GPIO13 (physical pin 33 / PWM1)
-    led_thread  = LEDThread(stop_evt=stop_evt, get_settings=get_settings, pin=13)
+    # Start LED thread (no-op if hardware is unavailable)
+    led_thread  = LEDThread(stop_evt=stop_evt, get_settings=get_settings)
 
 
     try:


### PR DESCRIPTION
## Summary
- Replace rpi_ws281x-based LED controller with pi5neo progressive-fill implementation
- Start LED thread with new interface and update tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9466a5b483308301d9116274d20c