### PR TITLE
Cycle screen brightness through preset levels

### DIFF
--- a/menu.json
+++ b/menu.json
@@ -23,7 +23,7 @@
       "title": "Settings",
       "items": [
         { "type": "group", "label": "Display" },
-        { "type": "number", "label": "Screen Brightness", "binding": "display.brightness", "min": 0, "max": 100, "step": 5 },
+        { "type": "select", "label": "Screen Brightness", "binding": "display.brightness", "options": [25,50,75,100] },
         { "type": "select", "label": "Rotation", "binding": "display.rotation", "options": [0,90,180,270] },
         { "type": "toggle", "label": "Screensaver", "binding": "display.screensaver_enabled" },
         { "type": "number", "label": "Sleep After (s)", "binding": "display.sleep_seconds", "min": 10, "max": 3600, "step": 10 },

--- a/tests/test_menu_engine.py
+++ b/tests/test_menu_engine.py
@@ -1,0 +1,22 @@
+import json
+import os
+
+from app.menu_engine import MenuController
+
+
+def test_screen_brightness_rotates():
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    with open(os.path.join(root, 'menu.json')) as f:
+        menu_spec = json.load(f)
+
+    settings = {"display": {"brightness": 25}}
+    mc = MenuController(menu_spec, settings, lambda s: None)
+
+    # Navigate to Settings -> Screen Brightness
+    mc.on_event("DOWN")   # focus Settings on home screen
+    mc.on_event("SELECT") # enter Settings
+    mc.on_event("DOWN")   # move focus to Screen Brightness item
+
+    for expected in [50, 75, 100, 25]:
+        mc.on_event("SELECT")
+        assert settings["display"]["brightness"] == expected


### PR DESCRIPTION
## Summary
- make screen brightness menu a select list cycling 25/50/75/100
- add test to ensure brightness setting rotates through fixed values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afa34670e483309eef38e771ff8af7