### PR TITLE
Add Bluetooth control menu and status indicator

### DIFF
--- a/app/bluetooth.py
+++ b/app/bluetooth.py
@@ -1,0 +1,76 @@
+import subprocess
+from typing import Dict, List
+
+
+def _run(cmd: List[str]) -> bool:
+    """Run a command, retrying with sudo if needed."""
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+        return True
+    except FileNotFoundError:
+        print(f"[Bluetooth] {' '.join(cmd)} not found")
+        return False
+    except subprocess.CalledProcessError as exc:
+        err = (exc.stderr or b"").decode().strip()
+        try:
+            subprocess.run(["sudo", *cmd], check=True, capture_output=True)
+            return True
+        except FileNotFoundError:
+            print(f"[Bluetooth] sudo {' '.join(cmd)} not found")
+            return False
+        except subprocess.CalledProcessError as exc2:
+            err2 = (exc2.stderr or b"").decode().strip()
+            print(f"[Bluetooth] {' '.join(cmd)} failed: {err or err2}")
+            return False
+
+
+def set_power(on: bool) -> bool:
+    return _run(["bluetoothctl", "power", "on" if on else "off"])
+
+
+def set_discoverable(on: bool) -> bool:
+    return _run(["bluetoothctl", "discoverable", "on" if on else "off"])
+
+
+def set_pairable(on: bool) -> bool:
+    return _run(["bluetoothctl", "pairable", "on" if on else "off"])
+
+
+def get_status() -> Dict[str, bool]:
+    """Return basic bluetoothctl show status."""
+    try:
+        out = subprocess.run(
+            ["bluetoothctl", "show"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return {"powered": False, "discoverable": False, "pairable": False}
+    status = {"powered": False, "discoverable": False, "pairable": False}
+    for line in out.splitlines():
+        if "Powered:" in line:
+            status["powered"] = line.strip().endswith("yes")
+        elif "Discoverable:" in line:
+            status["discoverable"] = line.strip().endswith("yes")
+        elif "Pairable:" in line:
+            status["pairable"] = line.strip().endswith("yes")
+    return status
+
+
+def list_paired_devices() -> List[str]:
+    try:
+        out = subprocess.run(
+            ["bluetoothctl", "paired-devices"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return []
+    devices = []
+    for line in out.splitlines():
+        parts = line.split(maxsplit=1)
+        if parts:
+            devices.append(parts[0])
+    return devices

--- a/app/led_controller.py
+++ b/app/led_controller.py
@@ -7,7 +7,7 @@
 import logging
 import threading
 import time
-from typing import Callable, Tuple
+from typing import Callable, NamedTuple
 
 try:
     from pi5neo import Pi5Neo
@@ -15,13 +15,17 @@ except Exception:
     Pi5Neo = None
     logging.warning("pi5neo not available; LED controller will be a no-op")
 
-Color = Tuple[int, int, int]
+class Color(NamedTuple):
+    """Simple RGB color container."""
+    r: int
+    g: int
+    b: int
 
 # If your LEDs expect GRB order instead of RGB, set ORDER = (1, 0, 2)
 ORDER = (0, 1, 2)  # (R, G, B) index order; change to (1,0,2) for GRB strips
 
 def _apply_order(c: Color) -> Color:
-    return (c[ORDER[0]], c[ORDER[1]], c[ORDER[2]])
+    return Color(c[ORDER[0]], c[ORDER[1]], c[ORDER[2]])
 
 class LEDThread(threading.Thread):
     """
@@ -65,7 +69,7 @@ class LEDThread(threading.Thread):
             b = 20
         # Expecting 0..255 scale
         # Scale unit colors (1,0,0) by b to (b,0,0) etc.
-        return tuple(int((v > 0) * b) for v in base)  # type: ignore[return-value]
+        return Color(*(int((v > 0) * b) for v in base))  # type: ignore[arg-type]
 
     def _set_all(self, color: Color) -> None:
         if not self.strip:

--- a/app/menu_engine.py
+++ b/app/menu_engine.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 import time
 from typing import Any, Dict, List, Callable
+from app.bluetooth import set_power, set_discoverable, set_pairable
 
 Event = str  # "UP" | "DOWN" | "SELECT" | "BACK"
 
@@ -24,6 +25,9 @@ LIVE_BINDINGS = {
     "display.brightness",
     "display.sleep_seconds",
     "display.screensaver_enabled",
+    "bluetooth.power",
+    "bluetooth.discoverable",
+    "bluetooth.pairable",
     # Wire more here as you implement them
 }
 
@@ -156,6 +160,12 @@ class MenuController:
         if binding in RESTART_BINDINGS:
             sys = self.settings.setdefault("system", {})
             sys["restart_required"] = True
+        if binding == "bluetooth.power":
+            set_power(bool(value))
+        elif binding == "bluetooth.discoverable":
+            set_discoverable(bool(value))
+        elif binding == "bluetooth.pairable":
+            set_pairable(bool(value))
         # Persist (debounced by the provided callback)
         self.save_cb(self.settings)
 
@@ -172,7 +182,11 @@ class MenuController:
             restart = b in RESTART_BINDINGS
 
         # Value string shown on the right
-        if t in ("group", "info", "action"):
+        if t in ("group", "action"):
+            value = ""
+        elif t == "info" and "binding" in it:
+            value = str(self._get_binding(it["binding"], ""))
+        elif t == "info":
             value = ""
         elif t == "toggle":
             value = "ON" if self._get_binding(it["binding"], False) else "OFF"

--- a/app/status.py
+++ b/app/status.py
@@ -2,12 +2,15 @@
 import subprocess
 import time
 from typing import Dict, Tuple, List, Optional
+from app import bluetooth
 
 class StatusProvider:
     def __init__(self, settings: Dict):
         self.settings = settings
         self._last_wifi_check = 0
         self._wifi_cached = (False, "")
+        self._last_bt_check = 0
+        self._bt_cached: Dict[str, bool] = {"powered": False, "discoverable": False}
 
     def snapshot(self) -> Dict[str, List[Tuple[str, Optional[str]]]]:
         now = time.time()
@@ -20,7 +23,23 @@ class StatusProvider:
             self._last_wifi_check = now
         connected, ssid = self._wifi_cached
 
+        if now - self._last_bt_check > 2:
+            try:
+                self._bt_cached = bluetooth.get_status()
+            except Exception:
+                self._bt_cached = {"powered": False, "discoverable": False}
+            self._last_bt_check = now
+        bt_state = self._bt_cached
+
         bar_right: List[Tuple[str, Optional[str]]] = []
+
+        bt_icon = "🅱"
+        if not bt_state.get("powered"):
+            bar_right.append((bt_icon, "#606060"))
+        elif bt_state.get("discoverable"):
+            bar_right.append((bt_icon, "#00FFFF"))
+        else:
+            bar_right.append((bt_icon, None))
 
         wifi_icon = "📶"
         if connected:

--- a/menu.json
+++ b/menu.json
@@ -7,6 +7,7 @@
       "items": [
         { "type": "screen-link", "label": "Shows",    "to": "shows" },
         { "type": "screen-link", "label": "Settings", "to": "settings" },
+        { "type": "screen-link", "label": "Bluetooth", "to": "bluetooth" },
         { "type": "action",      "label": "Shutdown", "action": "system.shutdown", "confirm": true }
       ]
     },
@@ -27,13 +28,22 @@
         { "type": "select", "label": "Rotation", "binding": "display.rotation", "options": [0,90,180,270] },
         { "type": "toggle", "label": "Screensaver", "binding": "display.screensaver_enabled" },
         { "type": "number", "label": "Sleep After (s)", "binding": "display.sleep_seconds", "min": 10, "max": 3600, "step": 10 },
-
         { "type": "group", "label": "LEDs" },
         { "type": "number", "label": "LED Brightness", "binding": "led.brightness", "min": 0, "max": 255, "step": 5 },
 
         { "type": "group", "label": "System" },
         { "type": "number", "label": "Animation Speed", "binding": "ui.anim_speed", "min": 1, "max": 10, "step": 1 },
         { "type": "number", "label": "Auto Shutdown (min)", "binding": "system.auto_shutdown_min", "min": 0, "max": 120, "step": 5 }
+      ]
+    },
+
+    "bluetooth": {
+      "title": "Bluetooth",
+      "items": [
+        { "type": "toggle", "label": "Power", "binding": "bluetooth.power" },
+        { "type": "toggle", "label": "Discoverable", "binding": "bluetooth.discoverable" },
+        { "type": "toggle", "label": "Pairable", "binding": "bluetooth.pairable" },
+        { "type": "info", "label": "Paired Devices", "binding": "bluetooth.paired_count" }
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Add dedicated Bluetooth menu with power, discoverable, and pairable toggles
- Show Bluetooth icon in status bar with color cues for power/discoverable state
- Provide utility functions for querying and configuring the adapter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b67a1a9c288330bcc56ace90aae2b0