### PR TITLE
Add web server thread for LED control and show server URL in menu

### DIFF
--- a/app/led_controller.py
+++ b/app/led_controller.py
@@ -99,7 +99,8 @@ class LEDThread(threading.Thread):
         self.strips_used = strips_used
         self.default_brightness = brightness
         self.hold_sec = hold_sec
-        self._pattern = "rgb_cycle"   # Option A: start in rgb_cycle
+        # Default to LEDs off; explicit actions can start test patterns
+        self._pattern = "off"
         self._pattern_lock = threading.Lock()
 
         self.port = port or find_teensy()
@@ -111,6 +112,16 @@ class LEDThread(threading.Thread):
 
         with self._pattern_lock:
             self._pattern = name
+
+    def start_test(self) -> None:
+        """Convenience wrapper to start the RGB test pattern."""
+
+        self.set_pattern("rgb_cycle")
+
+    def stop_test(self) -> None:
+        """Stop any active test pattern and turn LEDs off."""
+
+        self.set_pattern("off")
 
     # ------------------ internal helpers ------------------
     def _current_pattern(self) -> str:

--- a/app/ui_render.py
+++ b/app/ui_render.py
@@ -43,9 +43,12 @@ def render_menu(canvas, view, status, theme):
     row_h = 26
     padding = 8
 
+    footer = status.get("footer", "")
+    footer_h = 18 if footer else 0
+
     # Determine how many rows fit on the screen and which slice of items to draw
     items = view.get("items", [])
-    max_rows = max(1, (H - row_y) // row_h)
+    max_rows = max(1, (H - footer_h - row_y) // row_h)
     focus_idx = next((i for i, it in enumerate(items) if it.get("focused")), 0)
     top_idx = max(0, min(focus_idx - max_rows + 1, len(items) - max_rows))
     visible = items[top_idx : top_idx + max_rows]
@@ -76,4 +79,10 @@ def render_menu(canvas, view, status, theme):
             tw = d.textlength(value, font=font_row)
             d.text((W - padding - 6 - tw, row_y), value, fill=color, font=font_row)
         row_y += row_h
+
+    if footer:
+        d.line((0, H - footer_h, W, H - footer_h), fill="#404040")
+        font_footer = load_font(14)
+        tw = d.textlength(footer, font=font_footer)
+        d.text(((W - tw) // 2, H - footer_h + 2), footer, fill=fg, font=font_footer)
 

--- a/app/web_server.py
+++ b/app/web_server.py
@@ -1,0 +1,105 @@
+"""Simple web server thread to control the LED test via a phone.
+
+This module exposes :class:`WebServerThread` which hosts a minimal web page
+with *Start* and *Stop* buttons.  When the buttons are pressed the server
+invokes :meth:`LEDThread.set_pattern` on the provided LED thread.
+
+The server listens on all interfaces so the page can be opened from a phone on
+the same network.  It is intentionally lightweight and avoids external
+dependencies.
+"""
+
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from app.led_controller import LEDThread
+
+
+MAIN_PAGE = """<!doctype html>
+<html>
+<head>
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+<title>LED Control</title>
+<style>
+body { font-family: sans-serif; text-align: center; margin-top: 2em; }
+button { width: 80%; padding: 1em; font-size: 1.5em; margin: 1em 0; }
+</style>
+</head>
+<body>
+<h1>LED Test</h1>
+<form action=\"/start\" method=\"get\"><button type=\"submit\">Start</button></form>
+<form action=\"/stop\"  method=\"get\"><button type=\"submit\">Stop</button></form>
+</body>
+</html>"""
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Handle requests for the LED control page."""
+
+    # The HTTPServer instance will attach ``led_thread`` attribute at runtime.
+
+    def do_GET(self) -> None:  # pragma: no cover - trivial routing
+        if self.path == "/start":
+            self.server.led_thread.start_test()  # type: ignore[attr-defined]
+            self._redirect("/")
+        elif self.path == "/stop":
+            self.server.led_thread.stop_test()  # type: ignore[attr-defined]
+            self._redirect("/")
+        elif self.path == "/":
+            self._send_html(MAIN_PAGE)
+        else:
+            self.send_error(404, "Not found")
+
+    # ------------------------------------------------------------------
+    def log_message(self, format: str, *args: object) -> None:
+        """Silence default logging to keep console tidy."""
+
+        return
+
+    def _redirect(self, location: str) -> None:
+        self.send_response(303)
+        self.send_header("Location", location)
+        self.end_headers()
+
+    def _send_html(self, html: str) -> None:
+        data = html.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+class WebServerThread(threading.Thread):
+    """Background thread running a small HTTP server.
+
+    Parameters
+    ----------
+    stop_evt:
+        Event used to signal shutdown.
+    led_thread:
+        Instance of :class:`LEDThread` whose pattern will be controlled.
+    host, port:
+        Address where the server should listen.  Defaults to ``0.0.0.0:8000`` so
+        it can be reached from other devices on the LAN.
+    """
+
+    def __init__(self, stop_evt: threading.Event, led_thread: LEDThread, host: str = "0.0.0.0", port: int = 8000) -> None:
+        super().__init__(daemon=True)
+        self.stop_evt = stop_evt
+        self.led_thread = led_thread
+        self.host = host
+        self.port = port
+        self.httpd: HTTPServer = HTTPServer((host, port), _Handler)
+        # expose LED thread to handler via server attribute
+        self.httpd.led_thread = led_thread  # type: ignore[attr-defined]
+        self.httpd.timeout = 0.5  # so serve loop can check stop event
+
+    def run(self) -> None:  # pragma: no cover - contains blocking loop
+        print(f"[Web] server listening on {self.host}:{self.port}")
+        while not self.stop_evt.is_set():
+            self.httpd.handle_request()
+        self.httpd.server_close()
+        print("[Web] server stopped")

--- a/tests/test_led_controller.py
+++ b/tests/test_led_controller.py
@@ -68,3 +68,21 @@ def test_run_clears_on_start_when_stopped() -> None:
     # When stop is set before run, thread should clear strip once
     assert led.colors == [(0, 0, 0)]
 
+
+def test_start_stop_test_wrappers() -> None:
+    stop_evt = threading.Event()
+    thread = LEDThread(
+        stop_evt=stop_evt,
+        get_settings=lambda: {"led": {"brightness": 0}},
+        width=1,
+        height=1,
+        strips_used=1,
+        ser=DummySerial(),
+    )
+
+    assert thread._current_pattern() == "off"
+    thread.start_test()
+    assert thread._current_pattern() == "rgb_cycle"
+    thread.stop_test()
+    assert thread._current_pattern() == "off"
+

--- a/tests/test_status_provider.py
+++ b/tests/test_status_provider.py
@@ -1,0 +1,9 @@
+from app.status import StatusProvider
+
+
+def test_footer_contains_ip_and_port(monkeypatch):
+    settings = {"system": {}}
+    sp = StatusProvider(settings, web_port=1234)
+    monkeypatch.setattr(sp, "_get_local_ip", lambda: "10.0.0.5")
+    snap = sp.snapshot()
+    assert snap["footer"] == "http://10.0.0.5:1234"


### PR DESCRIPTION
## Summary
- add `WebServerThread` providing an HTTP server with start/stop buttons controlling the `LEDThread`
- server listens on all interfaces to support access from a phone on the LAN
- start `WebServerThread` from `main.py`
- default display rotation set to 180° so the screen is oriented correctly
- expose `start_test`/`stop_test` helpers so both menu actions and web page can toggle the LED test pattern
- show the server's URL at the bottom of the menu so users know what address to open on their phone

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be37880950833093b69df1b7157840