### PR TITLE
Add animation controller thread with websocket drawing UI

### DIFF
--- a/app/animation_controller.py
+++ b/app/animation_controller.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Callable, List, Set, Tuple, Optional
+
+try:  # pragma: no cover - serial may not be installed
+    import serial
+except Exception:  # pragma: no cover
+    serial = None  # type: ignore[assignment]
+
+from app.led_controller import find_teensy, send_frame
+
+Color = Tuple[int, int, int]
+
+
+class AnimationControllerThread(threading.Thread):
+    """Thread driving frames to LEDs and web clients.
+
+    The thread maintains an internal framebuffer and periodically pushes it to
+    the LED controller and any registered websocket clients.  Flags allow
+    runtime control over whether frames are sent to either destination.
+
+    Modes
+    -----
+    static:
+        Framebuffer is sent as-is.
+    animation:
+        Simple RGB cycling animation.
+    draw:
+        Framebuffer receives updates from ``update_pixel`` calls, typically
+        originating from a web drawing client.
+    """
+
+    def __init__(
+        self,
+        stop_evt: threading.Event,
+        width: int = 16,
+        height: int = 16,
+        port: Optional[str] = None,
+    ) -> None:
+        super().__init__(daemon=True)
+        self.stop_evt = stop_evt
+        self.width = width
+        self.height = height
+        self.port = port or find_teensy()
+        self.ser: Optional[serial.Serial] = None
+
+        self.mode = "static"
+        self.send_to_led = True
+        self.send_to_web = True
+
+        self._frame: List[List[Color]] = [
+            [(0, 0, 0) for _ in range(width)] for _ in range(height)
+        ]
+        self._frame_lock = threading.Lock()
+
+        # Web clients register a callable used to send JSON payloads
+        self._web_clients: Set[Callable[[str], None]] = set()
+
+    # ------------------------------------------------------------------
+    # Public API
+    def set_mode(self, mode: str) -> None:
+        """Set operating mode: ``static``, ``animation`` or ``draw``."""
+
+        if mode in {"static", "animation", "draw"}:
+            self.mode = mode
+
+    def register_client(self, sender: Callable[[str], None]) -> None:
+        """Register a callable used to send messages to a websocket client."""
+
+        self._web_clients.add(sender)
+
+    def unregister_client(self, sender: Callable[[str], None]) -> None:
+        self._web_clients.discard(sender)
+
+    def update_pixel(self, x: int, y: int, color: Color) -> None:
+        """Update a single pixel in the framebuffer."""
+
+        with self._frame_lock:
+            if 0 <= x < self.width and 0 <= y < self.height:
+                self._frame[y][x] = color
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _ensure_serial(self) -> Optional[serial.Serial]:
+        if self.ser:
+            return self.ser
+        if serial is None:  # pragma: no cover - serial missing
+            return None
+        try:
+            self.ser = serial.Serial(self.port, 2_000_000, timeout=0.2)
+        except Exception:  # pragma: no cover - hardware specific
+            self.ser = None
+        return self.ser
+
+    def _frame_bytes(self) -> bytes:
+        with self._frame_lock:
+            data = []
+            for row in self._frame:
+                for r, g, b in row:
+                    data.extend([g & 0xFF, r & 0xFF, b & 0xFF])
+            return bytes(data)
+
+    def _broadcast(self) -> None:
+        if not self.send_to_web:
+            return
+        with self._frame_lock:
+            payload = json.dumps({"frame": self._frame})
+        for sender in list(self._web_clients):
+            try:
+                sender(payload)
+            except Exception:
+                self._web_clients.discard(sender)
+
+    def _animate(self, t: float) -> None:
+        """Very small demo animation cycling primary colors."""
+
+        colors = [(255, 0, 0), (0, 255, 0), (0, 0, 255)]
+        idx = int(t) % len(colors)
+        col = colors[idx]
+        with self._frame_lock:
+            for y in range(self.height):
+                for x in range(self.width):
+                    self._frame[y][x] = col
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:  # pragma: no cover - contains time loop
+        print("[Anim] controller starting")
+        while not self.stop_evt.is_set():
+            now = time.time()
+            if self.mode == "animation":
+                self._animate(now)
+            # static and draw modes rely on external updates
+
+            payload = self._frame_bytes()
+            if self.send_to_led:
+                ser = self._ensure_serial()
+                if ser:
+                    try:
+                        send_frame(ser, payload, brightness=30)
+                    except Exception:
+                        pass
+            self._broadcast()
+            time.sleep(0.1)
+        print("[Anim] controller stopped")

--- a/app/led_controller.py
+++ b/app/led_controller.py
@@ -123,6 +123,14 @@ class LEDThread(threading.Thread):
 
         self.set_pattern("off")
 
+    def send_raw_frame(self, payload_grb: bytes, brightness: Optional[int] = None) -> None:
+        """Send a pre-built GRB payload to the LEDs."""
+
+        ser = self._ensure_serial()
+        if not ser:
+            return
+        send_frame(ser, payload_grb, brightness if brightness is not None else self._get_brightness())
+
     # ------------------ internal helpers ------------------
     def _current_pattern(self) -> str:
         with self._pattern_lock:

--- a/app/web_server.py
+++ b/app/web_server.py
@@ -1,61 +1,139 @@
-"""Simple web server thread to control the LED test via a phone.
-
-This module exposes :class:`WebServerThread` which hosts a minimal web page
-with *Start* and *Stop* buttons.  When the buttons are pressed the server
-invokes :meth:`LEDThread.set_pattern` on the provided LED thread.
-
-The server listens on all interfaces so the page can be opened from a phone on
-the same network.  It is intentionally lightweight and avoids external
-dependencies.
-"""
+"""Web server hosting control and drawing pages with websocket support."""
 
 from __future__ import annotations
 
+import asyncio
+import json
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
 
-from app.led_controller import LEDThread
+try:  # pragma: no cover - optional dependency
+    import websockets
+except Exception:  # pragma: no cover
+    websockets = None  # type: ignore[assignment]
+
+from app.animation_controller import AnimationControllerThread
 
 
-MAIN_PAGE = """<!doctype html>
+HOME_PAGE = """<!doctype html>
 <html>
 <head>
 <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
-<title>LED Control</title>
+<title>Alis</title>
 <style>
-body { font-family: sans-serif; text-align: center; margin-top: 2em; }
-button { width: 80%; padding: 1em; font-size: 1.5em; margin: 1em 0; }
+body { font-family: sans-serif; margin:0; }
+header { background:#333; color:white; padding:0.5em 1em; display:flex; align-items:center; }
+#menu { display:none; flex-direction:column; background:#444; position:absolute; top:3em; left:0; right:0; }
+#menu a { color:white; padding:0.5em 1em; text-decoration:none; }
+#hamburger { background:none; border:none; color:white; font-size:1.5em; margin-left:auto; }
+button { width:80%; padding:1em; font-size:1.2em; margin:1em 0; }
 </style>
+<script>
+function toggleMenu(){const m=document.getElementById('menu');m.style.display=m.style.display=='block'?'none':'block';}
+</script>
 </head>
 <body>
-<h1>LED Test</h1>
+<header><h1>Alis</h1><button id=\"hamburger\" onclick=\"toggleMenu()\">☰</button></header>
+<nav id=\"menu\"><a href=\"/\">Home</a><a href=\"/draw\">Draw</a></nav>
+<div id=\"content\">
+<h2>Show</h2>
 <form action=\"/start\" method=\"get\"><button type=\"submit\">Start</button></form>
-<form action=\"/stop\"  method=\"get\"><button type=\"submit\">Stop</button></form>
+<form action=\"/stop\" method=\"get\"><button type=\"submit\">Stop</button></form>
+</div>
+</body>
+</html>"""
+
+DRAW_PAGE = """<!doctype html>
+<html>
+<head>
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+<title>Draw</title>
+<style>
+body { font-family: sans-serif; margin:0; }
+header { background:#333; color:white; padding:0.5em 1em; display:flex; align-items:center; }
+#menu { display:none; flex-direction:column; background:#444; position:absolute; top:3em; left:0; right:0; }
+#menu a { color:white; padding:0.5em 1em; text-decoration:none; }
+#hamburger { background:none; border:none; color:white; font-size:1.5em; margin-left:auto; }
+.grid { display:grid; grid-template-columns:repeat(16,20px); grid-template-rows:repeat(16,20px); margin:1em; }
+.cell { width:20px; height:20px; border:1px solid #555; }
+.palette { margin:1em; }
+.swatch { width:20px; height:20px; display:inline-block; margin:0 5px; cursor:pointer; border:1px solid #000; }
+</style>
+<script>
+function toggleMenu(){const m=document.getElementById('menu');m.style.display=m.style.display=='block'?'none':'block';}
+const WS_PORT={ws_port};
+let current='#ff0000';
+let drawing=false;
+function init(){
+  const grid=document.getElementById('grid');
+  for(let y=0;y<16;y++){
+    for(let x=0;x<16;x++){
+      const c=document.createElement('div');c.className='cell';c.dataset.x=x;c.dataset.y=y;
+      c.addEventListener('mousedown',paint);
+      c.addEventListener('mouseover',e=>{if(drawing)paint(e);});
+      grid.appendChild(c);
+    }
+  }
+  grid.addEventListener('mousedown',()=>{drawing=true;});
+  document.addEventListener('mouseup',()=>{drawing=false;});
+  const palette=document.getElementById('palette');
+  ['#ff0000','#00ff00','#0000ff','#ffffff','#000000'].forEach(col=>{
+    const s=document.createElement('div');s.className='swatch';s.style.background=col;
+    s.addEventListener('click',()=>{current=col;});palette.appendChild(s);});
+  const ws=new WebSocket(`ws://${location.hostname}:${WS_PORT}`);
+  ws.onmessage=e=>{
+    const data=JSON.parse(e.data).frame;
+    const cells=grid.children;
+    for(let y=0;y<16;y++){
+      for(let x=0;x<16;x++){
+        const idx=y*16+x;
+        const rgb=data[y][x];
+        cells[idx].style.background=`rgb(${rgb[0]},${rgb[1]},${rgb[2]})`;
+      }
+    }
+  };
+  window._ws=ws;
+}
+function paint(e){
+  const cell=e.target;cell.style.background=current;
+  if(window._ws && window._ws.readyState===1){
+    window._ws.send(JSON.stringify({x:parseInt(cell.dataset.x),y:parseInt(cell.dataset.y),color:current}));
+  }
+}
+window.onload=init;
+</script>
+</head>
+<body>
+<header><h1>Alis</h1><button id=\"hamburger\" onclick=\"toggleMenu()\">☰</button></header>
+<nav id=\"menu\"><a href=\"/\">Home</a><a href=\"/draw\">Draw</a></nav>
+<div id=\"content\">
+<div id=\"grid\" class=\"grid\"></div>
+<div id=\"palette\" class=\"palette\"></div>
+</div>
 </body>
 </html>"""
 
 
 class _Handler(BaseHTTPRequestHandler):
-    """Handle requests for the LED control page."""
-
-    # The HTTPServer instance will attach ``led_thread`` attribute at runtime.
+    """Handle basic routing for pages and actions."""
 
     def do_GET(self) -> None:  # pragma: no cover - trivial routing
         if self.path == "/start":
-            self.server.led_thread.start_test()  # type: ignore[attr-defined]
+            self.server.anim_thread.set_mode("animation")  # type: ignore[attr-defined]
             self._redirect("/")
         elif self.path == "/stop":
-            self.server.led_thread.stop_test()  # type: ignore[attr-defined]
+            self.server.anim_thread.set_mode("static")  # type: ignore[attr-defined]
             self._redirect("/")
+        elif self.path == "/draw":
+            html = DRAW_PAGE.format(ws_port=self.server.ws_port)  # type: ignore[attr-defined]
+            self._send_html(html)
         elif self.path == "/":
-            self._send_html(MAIN_PAGE)
+            self._send_html(HOME_PAGE)
         else:
             self.send_error(404, "Not found")
 
-    # ------------------------------------------------------------------
-    def log_message(self, format: str, *args: object) -> None:
-        """Silence default logging to keep console tidy."""
-
+    def log_message(self, format: str, *args: Any) -> None:  # pragma: no cover
         return
 
     def _redirect(self, location: str) -> None:
@@ -73,33 +151,62 @@ class _Handler(BaseHTTPRequestHandler):
 
 
 class WebServerThread(threading.Thread):
-    """Background thread running a small HTTP server.
+    """Background server hosting HTTP pages and websocket endpoint."""
 
-    Parameters
-    ----------
-    stop_evt:
-        Event used to signal shutdown.
-    led_thread:
-        Instance of :class:`LEDThread` whose pattern will be controlled.
-    host, port:
-        Address where the server should listen.  Defaults to ``0.0.0.0:8000`` so
-        it can be reached from other devices on the LAN.
-    """
-
-    def __init__(self, stop_evt: threading.Event, led_thread: LEDThread, host: str = "0.0.0.0", port: int = 8000) -> None:
+    def __init__(
+        self,
+        stop_evt: threading.Event,
+        anim_thread: AnimationControllerThread,
+        host: str = "0.0.0.0",
+        port: int = 8000,
+    ) -> None:
         super().__init__(daemon=True)
         self.stop_evt = stop_evt
-        self.led_thread = led_thread
+        self.anim_thread = anim_thread
         self.host = host
         self.port = port
-        self.httpd: HTTPServer = HTTPServer((host, port), _Handler)
-        # expose LED thread to handler via server attribute
-        self.httpd.led_thread = led_thread  # type: ignore[attr-defined]
-        self.httpd.timeout = 0.5  # so serve loop can check stop event
+        self.ws_port = port + 1
+        self.httpd = HTTPServer((host, port), _Handler)
+        self.httpd.anim_thread = anim_thread  # type: ignore[attr-defined]
+        self.httpd.ws_port = self.ws_port  # type: ignore[attr-defined]
+        self.httpd.timeout = 0.5
+
+        self.loop = asyncio.new_event_loop()
+        if websockets:
+            self.ws_server = websockets.serve(self._ws_handler, host, self.ws_port)
+        else:
+            self.ws_server = None
+
+    async def _ws_handler(self, websocket: Any, path: str) -> None:  # pragma: no cover - network
+        send = lambda msg: asyncio.run_coroutine_threadsafe(websocket.send(msg), self.loop)
+        self.anim_thread.register_client(send)
+        try:
+            async for message in websocket:
+                try:
+                    data = json.loads(message)
+                    color = data.get("color", "#000000")
+                    r = int(color[1:3], 16)
+                    g = int(color[3:5], 16)
+                    b = int(color[5:7], 16)
+                    self.anim_thread.update_pixel(int(data.get("x", 0)), int(data.get("y", 0)), (r, g, b))
+                except Exception:
+                    continue
+        finally:
+            self.anim_thread.unregister_client(send)
 
     def run(self) -> None:  # pragma: no cover - contains blocking loop
+        ws = None
+        if websockets and self.ws_server:
+            asyncio.set_event_loop(self.loop)
+            ws = self.loop.run_until_complete(self.ws_server)
         print(f"[Web] server listening on {self.host}:{self.port}")
         while not self.stop_evt.is_set():
             self.httpd.handle_request()
+            if websockets and self.ws_server:
+                self.loop.run_until_complete(asyncio.sleep(0.05))
         self.httpd.server_close()
+        if ws:
+            ws.close()
+            self.loop.run_until_complete(ws.wait_closed())
+            self.loop.close()
         print("[Web] server stopped")


### PR DESCRIPTION
## Summary
- Introduce `AnimationControllerThread` to drive LED frames and broadcast to web clients.
- Expand web server with header navigation, draw page, and websocket endpoint for live LED drawing.
- Update main application to start animation controller and wire menu actions to it.
- Allow LED controller to send raw GRB frame payloads.

## Testing
- `pytest`
- `pip install websockets` *(fails: Could not find a version that satisfies the requirement websockets)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2e21252c8330a841c1c463f06541