### PR TITLE
Add test screen to menu and update navigation test

### DIFF
--- a/menu.json
+++ b/menu.json
@@ -16,6 +16,11 @@
         },
         {
           "type": "screen-link",
+          "label": "Test",
+          "to": "test"
+        },
+        {
+          "type": "screen-link",
           "label": "Settings",
           "to": "settings"
         },
@@ -35,16 +40,11 @@
           "label": "Program",
           "binding": "system.program_select",
           "options_source": "programs.list"
-        },
-        {
-          "type": "screen-link",
-          "label": "LED Test",
-          "to": "led-test"
         }
       ]
     },
-    "led-test": {
-      "title": "LED Test",
+    "test": {
+      "title": "Test",
       "items": [
         {
           "type": "action",

--- a/tests/test_menu_engine.py
+++ b/tests/test_menu_engine.py
@@ -13,6 +13,7 @@ def test_screen_brightness_rotates():
     mc = MenuController(menu_spec, settings, lambda s: None)
 
     # Navigate to Settings -> Screen Brightness
+    mc.on_event("DOWN")
     mc.on_event("DOWN")   # focus Settings on home screen
     mc.on_event("SELECT") # enter Settings
     mc.on_event("DOWN")   # move focus to Screen Brightness item


### PR DESCRIPTION
## Summary
- add Test screen to menu and link it from home
- remove LED Test link from shows menu and rename screen to `test`
- adjust menu engine test to navigate to Settings via updated menu

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c23cf951ec83308f4f3e4dced3d4f2