### PR TITLE
Cycle LED brightness through settings

### DIFF
--- a/app/menu_engine.py
+++ b/app/menu_engine.py
@@ -24,6 +24,7 @@ LIVE_BINDINGS = {
     "display.brightness",
     "display.sleep_seconds",
     "display.screensaver_enabled",
+    "led.brightness",
     # Wire more here as you implement them
 }
 

--- a/menu.json
+++ b/menu.json
@@ -105,12 +105,17 @@
           "label": "LEDs"
         },
         {
-          "type": "number",
+          "type": "select",
           "label": "LED Brightness",
           "binding": "led.brightness",
-          "min": 0,
-          "max": 255,
-          "step": 5
+          "options": [
+            0,
+            20,
+            40,
+            60,
+            80,
+            100
+          ]
         },
         {
           "type": "group",

--- a/tests/test_menu_engine.py
+++ b/tests/test_menu_engine.py
@@ -21,3 +21,27 @@ def test_screen_brightness_rotates():
     for expected in [50, 75, 100, 25]:
         mc.on_event("SELECT")
         assert settings["display"]["brightness"] == expected
+
+
+def test_led_brightness_rotates():
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    with open(os.path.join(root, 'menu.json')) as f:
+        menu_spec = json.load(f)
+
+    settings = {"led": {"brightness": 20}}
+    mc = MenuController(menu_spec, settings, lambda s: None)
+
+    # Navigate to Settings -> LED Brightness
+    mc.on_event("DOWN")
+    mc.on_event("DOWN")   # focus Settings on home screen
+    mc.on_event("SELECT") # enter Settings
+    mc.on_event("DOWN")   # Screen Brightness
+    mc.on_event("DOWN")   # Rotation
+    mc.on_event("DOWN")   # Screensaver
+    mc.on_event("DOWN")   # Sleep After
+    mc.on_event("DOWN")   # LEDs group
+    mc.on_event("DOWN")   # LED Brightness item
+
+    for expected in [40, 60, 80, 100, 0, 20]:
+        mc.on_event("SELECT")
+        assert settings["led"]["brightness"] == expected


### PR DESCRIPTION
## Summary
- Add LED brightness to live settings and cycle with 20% increments
- Update settings menu to step LED brightness in 20% increments
- Add tests for LED brightness cycling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c24104d15483309ccaeb36b65009f4